### PR TITLE
operators [O] cockroachdb (2.1.1)

### DIFF
--- a/operators/cockroachdb/2.1.1/manifests/cockroachdb.v2.1.1.clusterserviceversion.yaml
+++ b/operators/cockroachdb/2.1.1/manifests/cockroachdb.v2.1.1.clusterserviceversion.yaml
@@ -72,8 +72,6 @@ spec:
     ## About this Operator
 
 
-
-
     This Operator is based on a Helm chart for CockroachDB. It supports reconfiguration
     for some parameters, but notably does not handle scale down of the replica count
     in a seamless manner. Scale up works great.

--- a/operators/cockroachdb/2.1.1/manifests/cockroachdb.v2.1.1.clusterserviceversion.yaml
+++ b/operators/cockroachdb/2.1.1/manifests/cockroachdb.v2.1.1.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     # is compatible with it. Please, ensure that your project is no longer using these API(s) and that you start to
     # distribute solutions which is compatible with Openshift 4.9.
     # For further information, check the README of this repository.
-    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]'
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.9"}]'
     alm-examples: '[{"apiVersion":"charts.helm.k8s.io/v1alpha1","kind":"Cockroachdb","metadata":{"name":"example-cockroachdb"},"spec":{"CacheSize":"25%","ClusterDomain":"cluster.local","Component":"cockroachdb","ExternalGrpcName":"grpc","ExternalGrpcPort":26257,"ExternalHttpPort":8080,"HttpName":"http","Image":"cockroachdb/cockroach","ImagePullPolicy":"Always","ImageTag":"v2.1.5","InternalGrpcName":"grpc","InternalGrpcPort":26257,"InternalHttpPort":8080,"JoinExisting":[],"Locality":"","MaxSQLMemory":"25%","MaxUnavailable":1,"Name":"cockroachdb","NetworkPolicy":{"AllowExternal":true,"Enabled":false},"NodeSelector":{},"PodManagementPolicy":"Parallel","Replicas":3,"Resources":{},"Secure":{"Enabled":false,"RequestCertsImage":"cockroachdb/cockroach-k8s-request-cert","RequestCertsImageTag":"0.4","ServiceAccount":{"Create":true,"Name":null}},"Service":{"annotations":{},"type":"ClusterIP"},"Storage":"100Gi","StorageClass":null,"Tolerations":{},"UpdateStrategy":{"type":"RollingUpdate"}}}]'
     capabilities: Basic Install
     categories: Database

--- a/operators/cockroachdb/2.1.1/manifests/cockroachdb.v2.1.1.clusterserviceversion.yaml
+++ b/operators/cockroachdb/2.1.1/manifests/cockroachdb.v2.1.1.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ spec:
 
     This Operator is based on a Helm chart for CockroachDB. It supports reconfiguration
     for some parameters, but notably does not handle scale down of the replica count
-    in a seamless manner. Scale up works great..
+    in a seamless manner. Scale up works great.
 
     '
   displayName: CockroachDB

--- a/operators/cockroachdb/2.1.1/manifests/cockroachdb.v2.1.1.clusterserviceversion.yaml
+++ b/operators/cockroachdb/2.1.1/manifests/cockroachdb.v2.1.1.clusterserviceversion.yaml
@@ -72,6 +72,8 @@ spec:
     ## About this Operator
 
 
+
+
     This Operator is based on a Helm chart for CockroachDB. It supports reconfiguration
     for some parameters, but notably does not handle scale down of the replica count
     in a seamless manner. Scale up works great.

--- a/operators/cockroachdb/2.1.1/metadata/annotations.yaml
+++ b/operators/cockroachdb/2.1.1/metadata/annotations.yaml
@@ -1,5 +1,5 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: "stable-3.x"
+  operators.operatorframework.io.bundle.channel.default.v1: "stable"
   operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1


### PR DESCRIPTION
should fail only orange 4.9 (label missing)
and kiwi (maxOpenshiftVersions)