### PR TITLE
[ISV-4118] bootstrap 4.16 ocp-ci/dev

### DIFF
--- a/ci/legacy/scripts/ci/openshift-deploy-core.sh
+++ b/ci/legacy/scripts/ci/openshift-deploy-core.sh
@@ -24,7 +24,7 @@ case $PIPELINE_BRAND in
 esac
 
 
-declare -A OCP2K8S=( [4.6]=v1.19 [4.7]=v1.20 [4.8]=v1.21 [4.9]=v1.22 [4.10]=v1.23 [4.11]=v1.24 [4.12]=v1.25 [4.13]=v1.26 [4.14]=v1.27 [4.15]=v1.28 )
+declare -A OCP2K8S=( [4.6]=v1.19 [4.7]=v1.20 [4.8]=v1.21 [4.9]=v1.22 [4.10]=v1.23 [4.11]=v1.24 [4.12]=v1.25 [4.13]=v1.26 [4.14]=v1.27 [4.15]=v1.28 [4.16]=v1.29)
 PLAYBOOK_REPO='https://github.com/redhat-openshift-ecosystem/operator-test-playbooks.git'
 PLAYBOOK_REPO_BRANCH='upstream-community'
 echo "OCP_CLUSTER_VERSION_SUFFIX=$OCP_CLUSTER_VERSION_SUFFIX"

--- a/ci/scripts/opp-env.sh
+++ b/ci/scripts/opp-env.sh
@@ -2,7 +2,7 @@
 # OPerator Pipeline (OPP) env script (opp-env.sh)
 
 set -e
-declare -A KIND_SUPPORT_TABLE=(["1.28"]="0" ["1.27"]="3" ["1.26"]="6" ["1.25"]="11" ["1.24"]="15" ["1.23"]="17" ["1.22"]="17" ["1.21"]="14")
+declare -A KIND_SUPPORT_TABLE=(["1.29"]="0" ["1.28"]="4" ["1.27"]="8" ["1.26"]="11" ["1.25"]="16" ["1.24"]="16" ["1.23"]="17" ["1.22"]="17" ["1.21"]="14")
 KIND_MIN_SUPPORTED=1.21
 KIND_MAX_SUPPORTED=1.28 # DO NOT FORGET TO CHANGE WHEN CHANGING ^
 export INPUT_ENV_SCRIPT="/tmp/opp-env-vars"


### PR DESCRIPTION
Bootstrapping ocp 4.16 to ci/dev
---
Closes [ISV-4118](https://issues.redhat.com/browse/ISV-4118)