### PR TITLE
[ISV-4601] Re-enable slack monitoring

### DIFF
--- a/ci/templates/workflow/operator_release.yaml.js2
+++ b/ci/templates/workflow/operator_release.yaml.js2
@@ -1074,6 +1074,18 @@ jobs:
     if: failure()
     runs-on: ubuntu-latest
     steps:
+      - name: Report Status to a Slack
+        uses: ravsamhq/notify-slack-action@master
+        with:
+          notification_title: 'Release pipeline failed: ${{ needs.pr-check.outputs.opp_pr_title }}'
+          footer: 'monitoring'
+#          status: ${{ needs.pr-check.result }}
+          status: 'failure'
+          notify_when: 'failure'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+        continue-on-error: true
+
       - name: Google Chat Notification
         run: |
           echo "title: Release pipeline failed: ${{ needs.pr-check.outputs.opp_pr_title }}"


### PR DESCRIPTION
This commit re-enables old slack notifications. Gchat notifications are kept active.

Once this MR is "upgraded" to k8s repository, notifications will be manually checked to test whether old Slack channel still somewhere exists. Based on the observation, old channel will be activated or new channel will with a webhook will be created.

Once the Slack channel notifications are working correctly, old Gchat notifications and GChat channel will be removed/deprecated.