### PR TITLE
[ISV-46010] Move notifications from GChat to Slack channel

### DIFF
--- a/ci/templates/workflow/operator_release.yaml.js2
+++ b/ci/templates/workflow/operator_release.yaml.js2
@@ -1078,49 +1078,14 @@ jobs:
         uses: ravsamhq/notify-slack-action@master
         with:
           notification_title: 'Release pipeline failed: ${{ needs.pr-check.outputs.opp_pr_title }}'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>. <{workflow_url}|View Workflow>"
           footer: 'monitoring'
-#          status: ${{ needs.pr-check.result }}
           status: 'failure'
           notify_when: 'failure'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
         continue-on-error: true
 
-      - name: Google Chat Notification
-        run: |
-          echo "title: Release pipeline failed: ${{ needs.pr-check.outputs.opp_pr_title }}"
-          echo "subtitle: failure"
-          curl --location --request POST '${{ secrets.GCHAT_WEBHOOK }}' \
-          --header 'Content-Type: application/json' \
-          --data-raw '{
-              "cards": [
-                  {
-                      "header": {
-                          "title": "Release pipeline failed: ${{ needs.pr-check.outputs.opp_pr_title }}",
-                          "subtitle": "failure"
-                      },
-                      "sections": [
-                          {
-                              "widgets": [
-                                  {
-                                      "buttons": [
-                                          {
-                                              "textButton": {
-                                                  "text": "Open the release queue",
-                                                  "onClick": {
-                                                      "openLink": {
-                                                          "url": "https://github.com/${{ github.repository }}/actions/workflows/operator_release.yaml"
-                                                      }
-                                                  }
-                                              }
-                                          }
-                                      ]
-                                  }
-                              ]
-                          }
-                      ]
-                  }
-              ]
-          }'
 {% endraw %}
 {% endif %}


### PR DESCRIPTION
Slack notifications are extended with link to Workflow.

Old GChat notifications are removed.