### PR TITLE
fix(ISV-7322): freeze opm tag to mimic community-operators settings

### DIFF
--- a/ci/pipeline-config-k8s.yaml
+++ b/ci/pipeline-config-k8s.yaml
@@ -19,7 +19,7 @@ production:
     multiarch:
       base: quay.io/operator-framework/opm
       base_tags:
-        - latest
+        - v1.57.0
       postfix: s
     registry: quay.io
     organization: community-operators-pipeline


### PR DESCRIPTION
Assisted-by: Claude-4.6-Opus (Cursor) (helped me spot what's different between those repos)

This should make the test env work again.