### PR TITLE
Update, pin, and harden usage of actions/checkout

### DIFF
--- a/ci/templates/workflow/dco_test.yaml.js2
+++ b/ci/templates/workflow/dco_test.yaml.js2
@@ -33,7 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - id: files
         uses: masesgroup/retrieve-changed-files@v2
         continue-on-error: true

--- a/ci/templates/workflow/documentation.yaml.js2
+++ b/ci/templates/workflow/documentation.yaml.js2
@@ -26,8 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     container: quay.io/operator_testing/community-operators-mkdocs
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
+        persist-credentials: false
         repository: redhat-openshift-ecosystem/community-operators-pipeline
 {% endraw %}
 {% if default_config.pipeline.repo == 'redhat-openshift-ecosystem/community-operators-pipeline' %}

--- a/ci/templates/workflow/operator_convert.yaml.js2
+++ b/ci/templates/workflow/operator_convert.yaml.js2
@@ -36,8 +36,9 @@ jobs:
   convert:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: true # Conversion step pushes to the target branch when done and requires the privileged token
           token: ${{ secrets.FRAMEWORK_MERGE }}
       - name: Conversion
         run: |

--- a/ci/templates/workflow/operator_release.yaml.js2
+++ b/ci/templates/workflow/operator_release.yaml.js2
@@ -115,7 +115,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - id: files
         uses: masesgroup/retrieve-changed-files@v2
         continue-on-error: true
@@ -998,7 +1000,9 @@ jobs:
       OHIO_REGISTRY_IMAGE: "quay.io/operator-framework/upstream-community-operators:dev"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Prepare variables for the sign process
         id: openshift-vars-latest
         run: |

--- a/ci/templates/workflow/operator_test.yaml.js2
+++ b/ci/templates/workflow/operator_test.yaml.js2
@@ -261,8 +261,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Download operator_info
         uses: actions/download-artifact@v4
@@ -391,8 +392,9 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Operator test
         env:
@@ -420,8 +422,9 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Download operator_info
         uses: actions/download-artifact@v4
@@ -467,8 +470,9 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Operator test
         env:
@@ -500,8 +504,9 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Download operator_info
         uses: actions/download-artifact@v4

--- a/ci/templates/workflow/upgrade.yaml.js2
+++ b/ci/templates/workflow/upgrade.yaml.js2
@@ -48,11 +48,10 @@ jobs:
       - name: Install dependencies
         run: python -m pip install --upgrade pip yq
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: true # Commit files step pushes to the target branch when done and requires the privileged token
           token: ${{ secrets.FRAMEWORK_MERGE }}
-          #persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
-          # fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
       - name: Create local changes
         env:
           CLUSTER_TYPE: ${{ github.event.inputs.cluster }}


### PR DESCRIPTION
- Explicitly specify `persist-credentials` setting (false in all cases where we don't need to commit + push back to the branch or perform other similar tasks which require authentication)
- Pin the action used to a hash
  - I acknowledge that this probably will not get updated often, but then again this was previously on `actions/checkout@v3`, which was not getting further updates anyways.