### PR TITLE
fix(ISV-7300): try simply switching the target

### DIFF
--- a/ci/templates/workflow/operator_test.yaml.js2
+++ b/ci/templates/workflow/operator_test.yaml.js2
@@ -90,7 +90,7 @@ jobs:
           mkdir -p /tmp/pr_comments
           cat > /tmp/pr_comments/rebase.md <<'ENDOFCOMMENT'
           Dear @${{ github.event.pull_request.user.login }},
-          Your forked procject is not rebased
+          Your forked project is not rebased
           
           To fix this issue please rebase or execute following commands: 
           ```
@@ -195,7 +195,7 @@ jobs:
           ## Automatic Cluster Version Label (OCP) - packagemanifest only
 
           Starting OCP v4.9 (based on k8s 1.22) some old API were deprecated([Deprecated API Migration Guide from v1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22), [OKD/OpenShift Catalogs criteria and options](./packaging-required-criteria-ocp.md)). User can set `com.redhat.openshift.versions: <versions>`in its bundle `annotations.yaml` file to limit specific operator version to be visible on certain cluster.
-          Users can set label only when the operator is in bundle format. For packagemanifest format it is not possible to set this lablel, but community-operators pipeline can automatically set such label to the bundle. User have to allow it by putting packagemanifestClusterVersionLabel: auto in ci.yaml file
+          Users can set label only when the operator is in bundle format. For packagemanifest format it is not possible to set this label, but community-operators pipeline can automatically set such label to the bundle. User have to allow it by putting packagemanifestClusterVersionLabel: auto in ci.yaml file
 
           ```
           $ cat <path-to-operator>/ci.yaml
@@ -329,7 +329,7 @@ jobs:
           Dear @${{ github.event.pull_request.user.login }},        
           Some errors and/or warnings were found while doing the check of your operator (\`${{ needs.pr-check.outputs.opp_name }}/${{ needs.pr-check.outputs.opp_version }}\`) against the entire suite of validators for Operator Framework with [Operator-SDK](https://github.com/operator-framework/operator-sdk) version \`${{ steps.op-kiwi-test-err-bundle-validate.outputs.operator_sdk_version }}\` and the command \`$ operator-sdk bundle validate <bundle-path> ${{ steps.op-kiwi-test-err-bundle-validate.outputs.operator_sdk_args }}\`. 
           
-          **Errors (:bug:)  must be fixed while warnings (:warning:) are informative, and fixing them might improve the quality of your solution.**
+          **Errors (:bug:) must be fixed while warnings (:warning:) are informative, and fixing them might improve the quality of your solution.**
 
           ${{ steps.op-kiwi-test-err-bundle-validate.outputs.opp_check_err_bundle_validate }}
           ENDOFCOMMENT
@@ -348,7 +348,7 @@ jobs:
           mkdir -p /tmp/pr_comments
           cat > /tmp/pr_comments/maxOpenShiftVersion.md <<'ENDOFCOMMENT'
           Dear @${{ github.event.pull_request.user.login }},
-          :warning: | Your operator (`${{ needs.pr-check.outputs.opp_name }}/${{ needs.pr-check.outputs.opp_version }}`) might **not** run on k8s 1.22 or  in the Openshift version 4.9. **For more info see details bellow.**
+          :warning: | Your operator (`${{ needs.pr-check.outputs.opp_name }}/${{ needs.pr-check.outputs.opp_version }}`) might **not** run on k8s 1.22 or in the Openshift version 4.9. **For more info see details below.**
           :---: | :--- |
 
           **IMPORTANT** : Kubernetes has been deprecating API(s) which will be removed and no longer available in 1.22 and in the Openshift version 4.9. Note that your project will be unable to use them on OCP 4.9/K8s 1.22 and then, it is strongly recommended to check [Deprecated API Migration Guide from v1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22) and ensure that your projects have them migrated and are not using any deprecated API.

--- a/ci/templates/workflow/operator_test.yaml.js2
+++ b/ci/templates/workflow/operator_test.yaml.js2
@@ -2,7 +2,7 @@ name: Operator test
 
 {% raw %}
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize, unlabeled]
     branches:
       - master
@@ -32,7 +32,6 @@ env:
   OPP_MIRROR_INDEX_MULTIARCH_BASE: "{{ default_config.production.mirror.multiarch.base }}"
   OPP_MULTIARCH_SUPPORTED_VERSIONS: "{% for item in default_config.production.mirror.multiarch.base_tags %}{{ item }}{%- if not loop.last %} {% endif %}{% endfor %}"
   OPP_MIRROR_INDEX_MULTIARCH_POSTFIX: "s"
-  IIB_INPUT_REGISTRY_USER: "{{ default_config.production.mirror.username.in }}"
   OPP_PROD: 0
   OPP_DRY_RUN: 0
   # TODO handle config
@@ -44,7 +43,6 @@ env:
   OPP_FORCE_DEPLOY_ON_K8S_OPENSHIFT_VERSION: {{ default_config.test.force_deploy_openshift_version | default('4.10') }}
 #  ARTEFACT_PATH: "/tmp/operator-test" #hardcoded for now
 {% raw %}
-  IIB_INPUT_REGISTRY_TOKEN: ${{ secrets.IIB_INPUT_REGISTRY_TOKEN }}
 
 jobs:
   pr-check:
@@ -87,21 +85,18 @@ jobs:
           fi
 
       - name: Operator traffic light (comment)
-        id: op-traffic-light-comment
         if: always() && steps.op-traffic-light-result.outputs.git_rebase_conflict == '1'
-        uses: mshick/add-pr-comment@v1
-        with:
-          message: |
-            Dear @${{ github.event.pull_request.user.login }},
-            Your forked procject is not rebased
-            
-            To fix this issue please rebase or execute following commands: 
-            ```
-            ${{ steps.op-traffic-light-result.outputs.git_rebase_conflict_comment }}
-            ```
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
-          allow-repeats: true
+        run: |
+          mkdir -p /tmp/pr_comments
+          cat > /tmp/pr_comments/rebase.md <<'ENDOFCOMMENT'
+          Dear @${{ github.event.pull_request.user.login }},
+          Your forked procject is not rebased
+          
+          To fix this issue please rebase or execute following commands: 
+          ```
+          ${{ steps.op-traffic-light-result.outputs.git_rebase_conflict_comment }}
+          ```
+          ENDOFCOMMENT
 
       - name: Operator info
         id: op-info
@@ -149,34 +144,28 @@ jobs:
           [ -f /tmp/operator-test/op_failed_k8s_bundles.yaml ] && echo "opp_check_err_k8s_bundles_value=$(cat /tmp/operator-test/op_failed_k8s_bundles.yaml | yq -r '.operators | @csv' | tr -d '"')" >> $GITHUB_OUTPUT || true
           [ -f /tmp/operator-test/format_failed ] && echo "opp_check_err_package_manifest=1" >> $GITHUB_OUTPUT || true
 
-
       - name: Operator info (packagemanifest format failed)
-        id: op-info-comment-format
         if: always() && steps.op-info-result.outputs.opp_check_err_package_manifest == '1' && (steps.op-traffic-light.outputs.opp_op_delete == '0' || steps.op-traffic-light.outputs.opp_is_new_operatror == '1' || steps.op-traffic-light.outputs.opp_recreate == '1' ) && (steps.op-traffic-light.outputs.opp_ci_yaml_only == '0')
-        uses: mshick/add-pr-comment@v1
-        with:
-          message: |
-            Dear @${{ github.event.pull_request.user.login }},
-            your operator is in package manifest format. This format is not supported anymore. Please convert it to bundle format. [More info](https://docs.openshift.com/container-platform/4.12/operators/operator_sdk/osdk-pkgman-to-bundle.html)
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
-          allow-repeats: true
+        run: |
+          mkdir -p /tmp/pr_comments
+          cat > /tmp/pr_comments/packagemanifest.md <<'ENDOFCOMMENT'
+          Dear @${{ github.event.pull_request.user.login }},
+          your operator is in package manifest format. This format is not supported anymore. Please convert it to bundle format. [More info](https://docs.openshift.com/container-platform/4.12/operators/operator_sdk/osdk-pkgman-to-bundle.html)
+          ENDOFCOMMENT
 
       - name: Operator info (comment)
-        id: op-info-comment
         if: always() && steps.op-info-result.outputs.opp_check_err_k8s_bundles == '1' && (steps.op-traffic-light.outputs.opp_op_delete == '0' || steps.op-traffic-light.outputs.opp_is_new_operatror == '1' || steps.op-traffic-light.outputs.opp_recreate == '1' ) && (steps.op-traffic-light.outputs.opp_ci_yaml_only == '0')
-        uses: mshick/add-pr-comment@v1
-        with:
-          message: |
-            Dear @${{ github.event.pull_request.user.login }},
-            There are some operators version that are using **deprecated api** and kubernetes max versions (`operatorhub.io/ui-metadata-max-k8s-version`) is **NOT** set correctly under annotation field in CSV file.
-            
-            Affected versions : `${{ steps.op-info-result.outputs.opp_check_err_k8s_bundles_value }}`
-            
-            More info in 'Kubernetes max version in CSV' section [here](https://${{ env.OPP_THIS_REPO_ORG }}.github.io/${{ env.OPP_THIS_REPO_NAME }}/operator-ci-yaml/#kubernetes-max-version-in-csv).
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
-          allow-repeats: true
+        run: |
+          mkdir -p /tmp/pr_comments
+          cat > /tmp/pr_comments/k8s_bundles.md <<ENDOFCOMMENT
+          Dear @${{ github.event.pull_request.user.login }},
+          There are some operators version that are using **deprecated api** and kubernetes max versions (\`operatorhub.io/ui-metadata-max-k8s-version\`) is **NOT** set correctly under annotation field in CSV file.
+          
+          Affected versions : \`${{ steps.op-info-result.outputs.opp_check_err_k8s_bundles_value }}\`
+          
+          More info in 'Kubernetes max version in CSV' section [here](https://${{ env.OPP_THIS_REPO_ORG }}.github.io/${{ env.OPP_THIS_REPO_NAME }}/operator-ci-yaml/#kubernetes-max-version-in-csv).
+          ENDOFCOMMENT
+
 {% endraw %}
 {% else %}
 {% raw %}
@@ -188,42 +177,43 @@ jobs:
           echo "opp_check_err_package_manifest=" >> $GITHUB_OUTPUT
           [ -f /tmp/operator-test/op_auto_labels.yaml ] && echo "opp_check_err_cluster_version_autolabel=1" >> $GITHUB_OUTPUT || true
           [ -f /tmp/operator-test/format_failed ] && echo "opp_check_err_package_manifest=1" >> $GITHUB_OUTPUT || true
-      
+
       - name: Operator info (packagemanifest format failed)
-        id: op-info-comment-format
         if: always() && steps.op-info-result.outputs.opp_check_err_package_manifest == '1' && (steps.op-traffic-light.outputs.opp_op_delete == '0' || steps.op-traffic-light.outputs.opp_is_new_operatror == '1' || steps.op-traffic-light.outputs.opp_recreate == '1' ) && (steps.op-traffic-light.outputs.opp_ci_yaml_only == '0')
-        uses: mshick/add-pr-comment@v1
-        with:
-          message: |
-            Dear @${{ github.event.pull_request.user.login }},
-            your operator is in package manifest format. This format is not supported anymore. Please convert it to bundle format. [More info](https://docs.openshift.com/container-platform/4.12/operators/operator_sdk/osdk-pkgman-to-bundle.html)
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
-          allow-repeats: true
+        run: |
+          mkdir -p /tmp/pr_comments
+          cat > /tmp/pr_comments/packagemanifest.md <<'ENDOFCOMMENT'
+          Dear @${{ github.event.pull_request.user.login }},
+          your operator is in package manifest format. This format is not supported anymore. Please convert it to bundle format. [More info](https://docs.openshift.com/container-platform/4.12/operators/operator_sdk/osdk-pkgman-to-bundle.html)
+          ENDOFCOMMENT
 
       - name: Operator info (comment)
-        id: op-info-comment
         if: always() && steps.op-info-result.outputs.opp_check_err_cluster_version_autolabel == '1' && (steps.op-traffic-light.outputs.opp_op_delete == '0' || steps.op-traffic-light.outputs.opp_is_new_operatror == '1' )
-        uses: mshick/add-pr-comment@v1
-        with:
-          message: |
-            ## Automatic Cluster Version Label (OCP) - packagemanifest only
+        run: |
+          mkdir -p /tmp/pr_comments
+          cat > /tmp/pr_comments/autolabel.md <<'ENDOFCOMMENT'
+          ## Automatic Cluster Version Label (OCP) - packagemanifest only
 
-            Starting OCP v4.9 (based on k8s 1.22) some old API were deprecated([Deprecated API Migration Guide from v1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22), [OKD/OpenShift Catalogs criteria and options](./packaging-required-criteria-ocp.md)). User can set `com.redhat.openshift.versions: <versions>`in its bundle `annotations.yaml` file to limit specific operator version to be visible on certain cluster.
-            Users can set label only when the operator is in bundle format. For packagemanifest format it is not possible to set this lablel, but community-operators pipeline can automatically set such label to the bundle. User have to allow it by putting packagemanifestClusterVersionLabel: auto in ci.yaml file
+          Starting OCP v4.9 (based on k8s 1.22) some old API were deprecated([Deprecated API Migration Guide from v1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22), [OKD/OpenShift Catalogs criteria and options](./packaging-required-criteria-ocp.md)). User can set `com.redhat.openshift.versions: <versions>`in its bundle `annotations.yaml` file to limit specific operator version to be visible on certain cluster.
+          Users can set label only when the operator is in bundle format. For packagemanifest format it is not possible to set this lablel, but community-operators pipeline can automatically set such label to the bundle. User have to allow it by putting packagemanifestClusterVersionLabel: auto in ci.yaml file
 
-            ```
-            $ cat <path-to-operator>/ci.yaml
-            packagemanifestClusterVersionLabel: auto
-            ```
-            More info [here](https://${{ env.OPP_THIS_REPO_ORG }}.github.io/${{ env.OPP_THIS_REPO_NAME }}/operator-ci-yaml/#automatic-cluster-version-label-ocp-packagemanifest-only).
+          ```
+          $ cat <path-to-operator>/ci.yaml
+          packagemanifestClusterVersionLabel: auto
+          ```
+          More info [here](https://${{ env.OPP_THIS_REPO_ORG }}.github.io/${{ env.OPP_THIS_REPO_NAME }}/operator-ci-yaml/#automatic-cluster-version-label-ocp-packagemanifest-only).
+          ENDOFCOMMENT
 
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
-          allow-repeats: true
 {% endraw %}
 {% endif %}
 {% raw %}
+      - name: Upload pr-check comments
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr_comments
+          path: /tmp/pr_comments/
+          if-no-files-found: ignore
       - name: Upload operator_info
         uses: actions/upload-artifact@v4
         if: (steps.op-traffic-light.outputs.opp_op_delete == '0' || steps.op-traffic-light.outputs.opp_is_new_operatror == '1' || steps.op-traffic-light.outputs.opp_recreate == '1') && (steps.op-traffic-light.outputs.opp_ci_yaml_only == '0')
@@ -333,19 +323,16 @@ jobs:
 
       - name: "Comment operator_sdk_bundle_validate_warnings_and_errors if exists"
         if: always() && steps.op-kiwi-test-err-bundle-validate.outputs.opp_check_err_bundle_validate != ''
-        uses: mshick/add-pr-comment@v1
-        with:
-          message: |
-            Dear @${{ github.event.pull_request.user.login }},        
-            Some errors and/or warnings were found while doing the check of your operator (`${{ needs.pr-check.outputs.opp_name }}/${{ needs.pr-check.outputs.opp_version }}`) against the entire suite of validators for Operator Framework with [Operator-SDK](https://github.com/operator-framework/operator-sdk) version `${{ steps.op-kiwi-test-err-bundle-validate.outputs.operator_sdk_version }}` and the command `$ operator-sdk bundle validate <bundle-path> ${{ steps.op-kiwi-test-err-bundle-validate.outputs.operator_sdk_args }}`. 
-            
-            **Errors (:bug:)  must be fixed while warnings (:warning:) are informative, and fixing them might improve the quality of your solution.**
+        run: |
+          mkdir -p /tmp/pr_comments
+          cat > /tmp/pr_comments/bundle_validate.md <<ENDOFCOMMENT
+          Dear @${{ github.event.pull_request.user.login }},        
+          Some errors and/or warnings were found while doing the check of your operator (\`${{ needs.pr-check.outputs.opp_name }}/${{ needs.pr-check.outputs.opp_version }}\`) against the entire suite of validators for Operator Framework with [Operator-SDK](https://github.com/operator-framework/operator-sdk) version \`${{ steps.op-kiwi-test-err-bundle-validate.outputs.operator_sdk_version }}\` and the command \`$ operator-sdk bundle validate <bundle-path> ${{ steps.op-kiwi-test-err-bundle-validate.outputs.operator_sdk_args }}\`. 
+          
+          **Errors (:bug:)  must be fixed while warnings (:warning:) are informative, and fixing them might improve the quality of your solution.**
 
-            ${{ steps.op-kiwi-test-err-bundle-validate.outputs.opp_check_err_bundle_validate }}
-
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
-          allow-repeats: true
+          ${{ steps.op-kiwi-test-err-bundle-validate.outputs.opp_check_err_bundle_validate }}
+          ENDOFCOMMENT
 
       - name: "Search operator test error olm.maxOpenShiftVersion error"
         id: op-kiwi-test-err-maxOpenShiftVersion
@@ -357,28 +344,33 @@ jobs:
 
       - name: "Comment operator test error olm.maxOpenShiftVersion"
         if: always() && steps.op-kiwi-test-err-maxOpenShiftVersion.outputs.opp_check_err_maxOpenShiftVersion != '0'
-        uses: mshick/add-pr-comment@v1
-        with:
-          message: |
-            Dear @${{ github.event.pull_request.user.login }},
-            :warning: | Your operator (`${{ needs.pr-check.outputs.opp_name }}/${{ needs.pr-check.outputs.opp_version }}`) might **not** run on k8s 1.22 or  in the Openshift version 4.9. **For more info see details bellow.**
-            :---: | :--- |
+        run: |
+          mkdir -p /tmp/pr_comments
+          cat > /tmp/pr_comments/maxOpenShiftVersion.md <<'ENDOFCOMMENT'
+          Dear @${{ github.event.pull_request.user.login }},
+          :warning: | Your operator (`${{ needs.pr-check.outputs.opp_name }}/${{ needs.pr-check.outputs.opp_version }}`) might **not** run on k8s 1.22 or  in the Openshift version 4.9. **For more info see details bellow.**
+          :---: | :--- |
 
-            **IMPORTANT** : Kubernetes has been deprecating API(s) which will be removed and no longer available in 1.22 and in the Openshift version 4.9. Note that your project will be unable to use them on OCP 4.9/K8s 1.22 and then, it is strongly recommended to check [Deprecated API Migration Guide from v1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22) and ensure that your projects have them migrated and are not using any deprecated API.
-            To prevent workflow issues, its users will need to have installed in their OCP cluster a version of your operator compatible with 4.9 before they try to upgrade their cluster from any previous version to 4.9 or higher. However, If you still need to publish the operator bundles with any of these API(s) for use on earlier k8s/OCP versions, ensure that the operator bundle is configured accordingly:
-            Use the olm.openShiftMaxVersion property in the CSV to prevent the user from upgrading their OCP cluster before upgrading the installed operator version to any distribution which is compatible with:
-            ```yaml
-            apiVersion: operators.coreos.com/v1alpha1
-            kind: ClusterServiceVersion
-              metadata:
-                annotations:
-                  # Prevent cluster upgrades to OpenShift Version 4.9 when this
-                  # bundle is installed on the cluster
-                  "olm.properties": '[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]'
-            ```
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
-          allow-repeats: true
+          **IMPORTANT** : Kubernetes has been deprecating API(s) which will be removed and no longer available in 1.22 and in the Openshift version 4.9. Note that your project will be unable to use them on OCP 4.9/K8s 1.22 and then, it is strongly recommended to check [Deprecated API Migration Guide from v1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22) and ensure that your projects have them migrated and are not using any deprecated API.
+          To prevent workflow issues, its users will need to have installed in their OCP cluster a version of your operator compatible with 4.9 before they try to upgrade their cluster from any previous version to 4.9 or higher. However, If you still need to publish the operator bundles with any of these API(s) for use on earlier k8s/OCP versions, ensure that the operator bundle is configured accordingly:
+          Use the olm.openShiftMaxVersion property in the CSV to prevent the user from upgrading their OCP cluster before upgrading the installed operator version to any distribution which is compatible with:
+          ```yaml
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: ClusterServiceVersion
+            metadata:
+              annotations:
+                # Prevent cluster upgrades to OpenShift Version 4.9 when this
+                # bundle is installed on the cluster
+                "olm.properties": '[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]'
+          ```
+          ENDOFCOMMENT
+      - name: Upload pr comments
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr_comments_test
+          path: /tmp/pr_comments/
+          if-no-files-found: ignore
 
 {% endraw %}
 {% if default_config.production.type == 'k8s' %}
@@ -488,7 +480,6 @@ jobs:
           OPP_AUTO_PACKAGEMANIFEST_CLUSTER_VERSION_LABEL: "${{ needs.pr-check.outputs.opp_auto_packagemanifest_cluster_version_label }}"
           OPP_MIRROR_INDEX_ENABLED: 1
           OPP_IIB_INSTALL: 0
-          IIB_INPUT_REGISTRY_TOKEN: ${{ secrets.IIB_INPUT_REGISTRY_TOKEN }}
           OPERATOR_INDEX_TAG: ${{ matrix.index-tag }}
           OPP_INSTALLATION_SKIP: "${{ needs.pr-check.outputs.opp_installation_skipped }}"
           KIND_KUBE_VERSION: "${{ needs.pr-check.outputs.kind_kube_version }}"
@@ -540,7 +531,6 @@ jobs:
           OPERATOR_INDEX_TAG: ${{ matrix.index-tag }}
           OPP_MIRROR_INDEX_ENABLED: 1
           OPP_IIB_INSTALL: 1
-          IIB_INPUT_REGISTRY_TOKEN: ${{ secrets.IIB_INPUT_REGISTRY_TOKEN }}
           OPP_INSTALLATION_SKIP: "${{ needs.pr-check.outputs.opp_installation_skipped }}"
           OPP_NAME: "${{ needs.pr-check.outputs.opp_name }}"
           OPP_VERSION: "${{ needs.pr-check.outputs.opp_version }}"
@@ -577,22 +567,10 @@ jobs:
         run: |
           mkdir -p ./pr
           echo ${{ github.event.number }} > ./pr/NR
+          echo "${{ needs.pr-check.outputs.opp_ci_yaml_only }}" > ./pr/CI_YAML_ONLY
       - uses: actions/upload-artifact@v4
         with:
           name: pr
           path: pr/
 
-      - name: "Setting package-validated label"
-        if: needs.pr-check.outputs.opp_ci_yaml_only == '1'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        continue-on-error: true
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            github.rest.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ['package-validated']
-            })
 {% endraw %}

--- a/ci/templates/workflow/operator_workflow_complete.yaml.js2
+++ b/ci/templates/workflow/operator_workflow_complete.yaml.js2
@@ -36,13 +36,14 @@ jobs:
             });
             var fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
-      - run: unzip pr.zip
-      - name: 'PR Number'
+      - run: unzip -o pr.zip -d pr_data
+      - name: 'Read PR number'
         id: pr-number
         run: |
-          PR=$(tr -dc [0-9] <./NR)
+          PR=$(tr -dc [0-9] <./pr_data/NR)
           [ -z "$PR" ] && echo "Invalid PR number" && exit 1
           echo "pr=${PR}" >> $GITHUB_OUTPUT
+          [ -f ./pr_data/CI_YAML_ONLY ] && echo "ci_yaml_only=$(cat ./pr_data/CI_YAML_ONLY)" >> $GITHUB_OUTPUT || echo "ci_yaml_only=0" >> $GITHUB_OUTPUT
 
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: pr-labels
@@ -56,15 +57,58 @@ jobs:
               repo: context.repo.repo
             })
             return labels.data
-      # - name: Labels
-      #   id: pr-labels
-      #   continue-on-error: true
-      #   run: |
-      #     curl -L --header "Authorization: token ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/operator-framework/community-operators/issues/${{ steps.pr-number.outputs.pr }}/labels -o /tmp/labels.json
-      #     LABELS=$(cat /tmp/labels.json)
-      #     echo "labels=${LABELS//'%'/'%25'}" >> $GITHUB_OUTPUT
     outputs:
       pr: "${{ steps.pr-number.outputs.pr }}"
+      ci_yaml_only: "${{ steps.pr-number.outputs.ci_yaml_only }}"
+
+  post-comments:
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [pr]
+    steps:
+      - name: 'Download and post PR comments from artifacts'
+        if: needs.pr.outputs.pr != '0'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        continue-on-error: true
+        env:
+          PR: "${{ needs.pr.outputs.pr }}"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const { execSync } = require('child_process');
+
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner, repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+            });
+
+            for (const name of ['pr_comments', 'pr_comments_test']) {
+              const match = artifacts.data.artifacts.find(a => a.name === name);
+              if (!match) continue;
+              const dl = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner, repo: context.repo.repo,
+                artifact_id: match.id, archive_format: 'zip',
+              });
+              fs.writeFileSync(`${name}.zip`, Buffer.from(dl.data));
+              execSync(`unzip -o ${name}.zip -d comments`);
+            }
+
+            const dir = './comments';
+            if (fs.existsSync(dir)) {
+              for (const file of fs.readdirSync(dir).sort()) {
+                if (!file.endsWith('.md')) continue;
+                const body = fs.readFileSync(path.join(dir, file), 'utf8').trim();
+                if (!body) continue;
+                await github.rest.issues.createComment({
+                  issue_number: parseInt(process.env.PR),
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body,
+                });
+              }
+            }
 
   on-success:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR removes authentication requirement from the test pipeline and switches to pull_request. Comment management was moved to `workflow_run`, as suggested in the original ticket.

Assisted-by: Claude-4.6-Opus (Cursor)