### PR TITLE
Add FBC operator support for k8s/operatorhub.io pipeline

### DIFF
--- a/ci/scripts/opp-fbc.sh
+++ b/ci/scripts/opp-fbc.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# opp-fbc.sh — FBC (File-Based Catalog) support functions for opp.sh
+#
+# These functions extend the community-operators-pipeline CI to handle
+# operators that opt into the FBC workflow (fbc.enabled: true in ci.yaml).
+# They are sourced by opp.sh and called during the orange (release) stage
+# when OPP_PRODUCTION_TYPE is "k8s".
+#
+# Design mirrors community-operators-prod:
+#   operators/<name>/ci.yaml            fbc.enabled + catalog_mapping
+#   operators/<name>/catalog-templates/ olm.template.basic or olm.semver files
+#   catalogs/latest/<name>/catalog.yaml rendered output (committed to repo)
+#
+# The rendered catalogs/latest/ tree is built into the catalog image via
+# catalog.Dockerfile (opm serve /configs), replacing the upstream-registry-builder
+# SQLite path for FBC-enabled operators.
+
+OPP_FBC_OPM_VERSION=${OPP_FBC_OPM_VERSION-"v1.46.0"}
+OPP_FBC_YQ_VERSION=${OPP_FBC_YQ_VERSION-"v4.45.1"}
+OPP_FBC_RENDER_SCRIPT_URL=${OPP_FBC_RENDER_SCRIPT_URL-"https://raw.githubusercontent.com/redhat-openshift-ecosystem/operator-pipelines/main/fbc/render_catalogs.sh"}
+OPP_FBC_BIN_DIR=${OPP_FBC_BIN_DIR-"/tmp/opp-fbc-bin"}
+OPP_FBC_CATALOG_DIR=${OPP_FBC_CATALOG_DIR-"catalogs/latest"}
+
+# opp_fbc_is_enabled <operator_dir>
+# Returns 0 (true) if the operator at $1 has fbc.enabled: true in ci.yaml.
+function opp_fbc_is_enabled() {
+    local op_dir="$1"
+    local ci_yaml="$op_dir/ci.yaml"
+    [ -f "$ci_yaml" ] || return 1
+    local enabled
+    enabled=$(command -v yq &>/dev/null && yq '.fbc.enabled // false' "$ci_yaml" 2>/dev/null \
+              || python3 -c "import sys,yaml; d=yaml.safe_load(open('$ci_yaml')); print(d.get('fbc',{}).get('enabled',False))" 2>/dev/null \
+              || echo "false")
+    [ "$enabled" = "true" ]
+}
+
+# opp_fbc_install_tools
+# Downloads opm and yq into OPP_FBC_BIN_DIR if not already present.
+function opp_fbc_install_tools() {
+    local os arch
+    os=$(uname -s | tr '[:upper:]' '[:lower:]')
+    arch=$(uname -m | sed 's/x86_64/amd64/')
+    mkdir -p "$OPP_FBC_BIN_DIR"
+
+    if [ ! -x "$OPP_FBC_BIN_DIR/opm" ]; then
+        echo "[fbc] Downloading opm ${OPP_FBC_OPM_VERSION}..."
+        curl -sLo "$OPP_FBC_BIN_DIR/opm" \
+            "https://github.com/operator-framework/operator-registry/releases/download/${OPP_FBC_OPM_VERSION}/${os}-${arch}-opm"
+        chmod +x "$OPP_FBC_BIN_DIR/opm"
+    fi
+
+    if [ ! -x "$OPP_FBC_BIN_DIR/yq" ]; then
+        echo "[fbc] Downloading yq ${OPP_FBC_YQ_VERSION}..."
+        curl -sLo "$OPP_FBC_BIN_DIR/yq" \
+            "https://github.com/mikefarah/yq/releases/download/${OPP_FBC_YQ_VERSION}/yq_${os}_${arch}"
+        chmod +x "$OPP_FBC_BIN_DIR/yq"
+    fi
+
+    if [ ! -x "$OPP_FBC_BIN_DIR/render_catalogs.sh" ]; then
+        echo "[fbc] Downloading render_catalogs.sh..."
+        curl -sLo "$OPP_FBC_BIN_DIR/render_catalogs.sh" "$OPP_FBC_RENDER_SCRIPT_URL"
+        chmod +x "$OPP_FBC_BIN_DIR/render_catalogs.sh"
+    fi
+
+    export PATH="$OPP_FBC_BIN_DIR:$PATH"
+}
+
+# opp_fbc_render_catalogs <repo_root> <operator_name>
+# Renders catalog-templates/ into catalogs/latest/<operator>/catalog.yaml.
+# Must be called from the repository root.
+function opp_fbc_render_catalogs() {
+    local repo_root="$1"
+    local operator_name="$2"
+    local op_dir="$repo_root/operators/$operator_name"
+
+    echo "[fbc] Rendering catalogs for $operator_name..."
+    (cd "$op_dir" && TOPDIR="$repo_root" bash "$OPP_FBC_BIN_DIR/render_catalogs.sh")
+    local rc=$?
+    if [ $rc -ne 0 ]; then
+        echo "[fbc] ERROR: render_catalogs.sh failed for $operator_name (exit $rc)"
+        return $rc
+    fi
+    echo "[fbc] Rendered: $repo_root/$OPP_FBC_CATALOG_DIR/$operator_name/catalog.yaml"
+}
+
+# opp_fbc_validate <repo_root> <operator_name>
+# Runs opm validate on the rendered catalog for the operator.
+function opp_fbc_validate() {
+    local repo_root="$1"
+    local operator_name="$2"
+    local catalog_path="$repo_root/$OPP_FBC_CATALOG_DIR/$operator_name"
+
+    if [ ! -d "$catalog_path" ]; then
+        echo "[fbc] ERROR: catalog path not found: $catalog_path"
+        return 1
+    fi
+
+    echo "[fbc] Validating $catalog_path..."
+    "$OPP_FBC_BIN_DIR/opm" validate "$catalog_path"
+    local rc=$?
+    if [ $rc -ne 0 ]; then
+        echo "[fbc] ERROR: opm validate failed for $operator_name"
+        return $rc
+    fi
+    echo "[fbc] ✅ Validation passed: $operator_name"
+}
+
+# opp_fbc_process <repo_root> <operator_name>
+# Full FBC pipeline for one operator: install tools, render, validate.
+# Called from opp.sh orange (release) flow when fbc.enabled: true.
+function opp_fbc_process() {
+    local repo_root="$1"
+    local operator_name="$2"
+
+    opp_fbc_install_tools || return 1
+    opp_fbc_render_catalogs "$repo_root" "$operator_name" || return 1
+    opp_fbc_validate "$repo_root" "$operator_name" || return 1
+    echo "[fbc] ✅ FBC processing complete for $operator_name"
+}

--- a/ci/scripts/opp.sh
+++ b/ci/scripts/opp.sh
@@ -60,6 +60,18 @@ OPP_NOCOLOR=${OPP_NOCOLOR-0}
 
 OPP_PACKAGEMANIFEST_DISABLED=${OPP_PACKAGEMANIFEST_DISABLED-0}
 
+# FBC (File-Based Catalog) support — k8s/operatorhub.io
+# Source the FBC helper functions.  The script is co-located with opp.sh;
+# when downloaded via curl the companion file is fetched from the same URL base.
+OPP_FBC_SCRIPT_URL="${OPP_THIS_REPO_BASE}/redhat-openshift-ecosystem/community-operators-pipeline/raw/ci/latest/ci/scripts/opp-fbc.sh"
+_OPP_FBC_LOCAL="$(dirname "${BASH_SOURCE[0]}")/opp-fbc.sh"
+if [ -f "$_OPP_FBC_LOCAL" ]; then
+    # shellcheck source=ci/scripts/opp-fbc.sh
+    source "$_OPP_FBC_LOCAL"
+else
+    source <(curl -sL "$OPP_FBC_SCRIPT_URL") || echo "[fbc] WARNING: could not load opp-fbc.sh; FBC operators will be skipped"
+fi
+
 OPP_RELEASE_BUNDLE_REGISTRY=${OPP_RELEASE_BUNDLE_REGISTRY-"quay.io"}
 OPP_RELEASE_BUNDLE_ORGANIZATION=${OPP_RELEASE_BUNDLE_ORGANIZATION-"community-operators-pipeline"}
 OPP_RELEASE_INDEX_REGISTRY=${OPP_RELEASE_INDEX_REGISTRY-"quay.io"}
@@ -701,6 +713,24 @@ for t in $TESTS;do
     echo "$OPP_EXEC_BASE $OPP_EXEC_EXTRA $OPP_EXEC_USER"
     run $DRY_RUN_CMD $OPP_CONTAINER_TOOL exec $OPP_CONTAINER_OPT $OPP_NAME /bin/bash -c "update-ca-trust && $OPP_EXEC_BASE $OPP_EXEC_EXTRA $OPP_EXEC_USER $OPP_EXEC_USER_SECRETS"
     set +e
+
+    # FBC post-processing: render and validate catalogs for FBC-enabled operators.
+    # Applies to k8s orange (release) stage only; OCP uses IIB instead.
+    # The operator bundle has been built and pushed above; this step updates the
+    # catalogs/latest/<operator>/catalog.yaml in the repository clone so that the
+    # catalog image can be rebuilt from the rendered FBC tree.
+    if [[ $t1 == orange* ]] && [ "$OPP_CLUSTER_TYPE" = "k8s" ] && [[ $OPP_PROD -ge 1 ]]; then
+        OPP_FBC_OPERATOR_DIR="$OPP_BASE_DIR/$OPP_OPERATORS_DIR/$OPP_OPERATOR"
+        if declare -f opp_fbc_is_enabled > /dev/null && opp_fbc_is_enabled "$OPP_FBC_OPERATOR_DIR"; then
+            echo "[fbc] FBC operator detected: $OPP_OPERATOR — running FBC catalog render/validate"
+            OPP_FBC_REPO_ROOT="$OPP_BASE_DIR"
+            opp_fbc_process "$OPP_FBC_REPO_ROOT" "$OPP_OPERATOR" || {
+                echo "[fbc] ERROR: FBC processing failed for $OPP_OPERATOR"
+                exit 1
+            }
+        fi
+    fi
+
     echo -e "Test '$t' : [ OK ]\n"
 done
 


### PR DESCRIPTION
## Summary

Extends `opp.sh` and adds a companion `opp-fbc.sh` to detect and process
operators that use the File-Based Catalog workflow (`fbc.enabled: true` in
`ci.yaml`) during the **orange/release** stage on k8s.  The OCP/IIB path
is unchanged.

## What this PR adds

### `ci/scripts/opp-fbc.sh` (new)

Sourced by `opp.sh` automatically (local file or fetched from the same URL
base).  Provides:

| Function | Purpose |
|---|---|
| `opp_fbc_is_enabled <op_dir>` | Returns `true` when `ci.yaml` has `fbc.enabled: true` |
| `opp_fbc_install_tools` | Downloads `opm`, `yq`, `render_catalogs.sh` on demand |
| `opp_fbc_render_catalogs <root> <op>` | Runs `render_catalogs.sh` → `catalogs/latest/<op>/catalog.yaml` |
| `opp_fbc_validate <root> <op>` | Runs `opm validate` on the rendered catalog |
| `opp_fbc_process <root> <op>` | Orchestrates install → render → validate |

### `ci/scripts/opp.sh` (patch)

- Sources `opp-fbc.sh` after the variable block
- After the Ansible bundle-release step, calls `opp_fbc_process` when:
  - `OPP_CLUSTER_TYPE=k8s` (not OCP)
  - Test stage is `orange` (release)
  - `OPP_PROD >= 1`
  - Operator has `fbc.enabled: true` in `ci.yaml`

## PR sequence and dependencies

This is **PR 2 of 3**:

```
PR 1 → k8s-operatorhub/community-operators          (catalog structure + Dockerfile + CI workflow)
PR 2 → redhat-openshift-ecosystem/community-operators-pipeline  (this PR — opp.sh FBC support)
PR 3 → redhat-openshift-ecosystem/operator-test-playbooks       (fbc_release Ansible tag)
```

This PR (2) can merge independently — it takes effect immediately because
`community-operators` downloads `opp.sh` fresh on every CI run.  PR 3
completes the catalog image build path via the Ansible playbook layer.

## Backward compatibility

Non-FBC operators are completely unaffected.  The existing kiwi/lemon/orange
flow and IIB integration are unchanged.  The FBC block only executes when
`opp_fbc_is_enabled` returns true.